### PR TITLE
Fix invalid class name for Swig-wx

### DIFF
--- a/swig-wx.rb
+++ b/swig-wx.rb
@@ -1,7 +1,7 @@
 
 require 'formula'
 
-class Swig-wx < Formula
+class SwigWx < Formula
   url 'git://github.com/wg-debs/swig-wx.git', {:using => :git, :tag => 'upstream/1.3.29'}
   homepage 'http://www.swig.org'
   version '1.3.29'


### PR DESCRIPTION
I was seeing `brew doctor` throw the error below, because the Swig-wx class name is not a valid class name in Ruby. Namely, it can't contain the dash. So I've updated it to use camelcasing.

```
Error: /Users/mathiasx/Developer/Library/Formula/swig-wx.rb:4: syntax error, unexpected '-', expecting '<' or '
' or ';'
class Swig-wx < Formula
           ^
Please report this bug:
    https://github.com/mxcl/homebrew/wiki/bug-fixing-checklist
/Users/mathiasx/Developer/Library/Homebrew/formula.rb:390:in `require'
/Users/mathiasx/Developer/Library/Homebrew/formula.rb:390:in `factory'
/Users/mathiasx/Developer/Library/Homebrew/formula.rb:311:in `each'
/Users/mathiasx/Developer/Library/Homebrew/formula.rb:309:in `each'
/Users/mathiasx/Developer/Library/Homebrew/formula.rb:305:in `map'
/Users/mathiasx/Developer/Library/Homebrew/formula.rb:301:in `all'
/Users/mathiasx/Developer/Library/Homebrew/cmd/doctor.rb:708:in `check_for_linked_kegonly_brews'
/Users/mathiasx/Developer/Library/Homebrew/cmd/doctor.rb:925:in `send'
/Users/mathiasx/Developer/Library/Homebrew/cmd/doctor.rb:925:in `doctor'
/Users/mathiasx/Developer/Library/Homebrew/cmd/doctor.rb:924:in `each'
/Users/mathiasx/Developer/Library/Homebrew/cmd/doctor.rb:924:in `doctor'
/Users/mathiasx/Developer/bin/brew:83:in `send'
/Users/mathiasx/Developer/bin/brew:83
```
