### PR TITLE
Update formula generation scripts to use stack.xml, not stack.yaml

### DIFF
--- a/distribution/generate-homebrew-formula.py
+++ b/distribution/generate-homebrew-formula.py
@@ -70,6 +70,7 @@ special_installs['genlisp'] = \
 '''
 
 pipkey_to_importtest_map = {}
+pipkey_to_importtest_map['PyYAML'] = 'yaml'
 pipkey_to_importtest_map['empy'] = 'em'
 
 def generate_brew(stack_xml, repo_url, ros_distro):


### PR DESCRIPTION
The existing formula generation scripts do not reflect recent changes to catkin. This patch updates them to reflect these changes.
